### PR TITLE
Skip setup when binaries are already present

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -8,6 +8,11 @@ var https = require('follow-redirects').https,
     util  = require("../cli/util"),
     pkg   = require("../package.json");
 
+if (fs.existsSync(util.bindir)) {
+    process.stdout.write(chalk.white.bold("Already have binaries, skipping download...") + "\n");
+    process.exit(0);
+}
+
 var platform = process.platform + "-" + process.arch,
     isWindows = /^win32/.test(platform),
     temp = tmp.fileSync({ prefix: "wa-tools-" }),


### PR DESCRIPTION
No reason to re-download everything when running `npm link` for example.

I have another small gripe you maybe have some insight into :) when depending on this module via `github:dcodeIO/webassembly` npm will checkout all submodules as well, which takes a looooong time. Any way to stop that?