### PR TITLE
Fix bad code generation

### DIFF
--- a/cli/compiler.js
+++ b/cli/compiler.js
@@ -107,7 +107,7 @@ exports.main = (argv, callback) => {
 
     util.run(path.join(util.bindir, "clang"), [
         file,
-        argv.bare || links.length || !argv.optimize ? undefined : "-O",
+        (argv.bare && !argv.optimize) || links.length || !argv.optimize ? undefined : "-O3",
         "-c",
         "--target=wasm32-unknown-unknown",
         "-emit-llvm",


### PR DESCRIPTION
This is a fix for #23.

It seems that adding optimization `-O3` generates the expected code.  I'm also unsure why optimization was turned off if the `bare` option was set, so maybe this is a bad idea.