### PR TITLE
Clarified installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,16 @@ require("webassembly")
 Installation
 ------------
 
+As a dependency:
+
 ```
 $> npm install webassembly
+```
+
+OR to use globally with "wa compile":
+
+```
+$> npm install -g webassembly
 ```
 
 Installing the package automatically downloads prebuilt binaries for either Windows (`win32-x64`) or Linux (`linux-x64`).


### PR DESCRIPTION
Clarified the distinction between a dependency and global installation. Some people (like myself) might be coming from not that JS heavy background, just searching for a quick WASM compiler and get confused about why "wa compile" does not work. I did.